### PR TITLE
package/ply: build needs flex and bison

### DIFF
--- a/package/ply/ply.mk
+++ b/package/ply/ply.mk
@@ -10,5 +10,6 @@ PLY_AUTORECONF = YES
 PLY_LICENSE = GPL-2.0
 PLY_LICENSE_FILES = COPYING
 PLY_INSTALL_STAGING = YES
+PLY_DEPENDENCIES = host-flex host-bison
 
 $(eval $(autotools-package))


### PR DESCRIPTION
Building needs flex and bison installed on the host system.

Fixes:
http://autobuild.buildroot.net/results/7cfe75725f4746367f2870ee9545f31ba56f6ec1

Signed-off-by: Andreas Klinger <ak@it-klinger.de>
Signed-off-by: Peter Korsgaard <peter@korsgaard.com>