### PR TITLE
package/dhcpcd: disable privsep on older kernels

### DIFF
--- a/package/dhcpcd/dhcpcd.mk
+++ b/package/dhcpcd/dhcpcd.mk
@@ -16,8 +16,23 @@ DHCPCD_CONFIG_OPTS = \
 	--os=linux \
 	--privsepuser=dhcpcd
 
-# AUDIT_ARCH_NDS32 is only available since kernel >= 5.2
-ifeq ($(BR2_nds32):$(BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_2),y:)
+# AUDIT_ARCH_{OPENRISC,SH,SHEL,SH64,SHEL64} are only available with kernel >= 3.7
+ifeq ($(BR2_or1k)$(BR2_sh):$(BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_7),y:)
+DHCPCD_CONFIG_OPTS += --disable-privsep
+endif
+
+# AUDIT_ARCH_MICROBLAZE is only available with kernel >= 3.18
+ifeq ($(BR2_microblazeel)$(BR2_microblazebe):$(BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_18),y:)
+DHCPCD_CONFIG_OPTS += --disable-privsep
+endif
+
+# AUDIT_ARCH_XTENSA is only available with kernel >= 5.0
+ifeq ($(BR2_xtensa):$(BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_0),y:)
+DHCPCD_CONFIG_OPTS += --disable-privsep
+endif
+
+# AUDIT_ARCH_{ARCOMPACT,ARCV2,NDS32,NIOS2} are only available with kernel >= 5.2
+ifeq ($(BR2_arceb)$(BR2_arcle)$(BR2_nds32)$(BR2_nios2):$(BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_2),y:)
 DHCPCD_CONFIG_OPTS += --disable-privsep
 endif
 


### PR DESCRIPTION
Commit e5594f7239547672c08058b77f8098d2c080bebc fixed privsep for sh,
or1k, microblaze, xtensa, arc, nds32 and nios2, but failed to take into
account that the audit functionality is only available in recent kernels
on those architectures.

Pass the --disable-privsep configure option if the kernel is too old in
those architectures.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>